### PR TITLE
New formula: tidy-html5

### DIFF
--- a/tidy-html5.rb
+++ b/tidy-html5.rb
@@ -1,0 +1,18 @@
+class TidyHtml5 < Formula
+  homepage "http://w3c.github.io/tidy-html5/"
+  head "https://github.com/w3c/tidy-html5.git"
+
+  def install
+    ENV.deparallelize
+
+    system "make", "-C", "build/gmake"
+    system "make", "installexes", "installmanpage", "-C", "build/gmake",
+                   "runinst_prefix=#{prefix}",
+                   "devinst_prefix=#{prefix}",
+                   "maninst=#{man}"
+  end
+
+  test do
+    system "tidy"
+  end
+end


### PR DESCRIPTION
This is the W3C's fork of `tidy` (an HTML pretty-printer/fixing tool) which runs on HTML5. Unfortunately the W3C hasn't seen fit to actually tag any releases.