### PR TITLE
galeb (new formula, head-only)

### DIFF
--- a/galeb.rb
+++ b/galeb.rb
@@ -1,0 +1,33 @@
+class Galeb < Formula
+  homepage "http://galeb.io/"
+
+  depends_on :java => "1.7+"
+  depends_on "vert.x"
+
+  head do
+    url "https://github.com/globocom/galeb.git"
+    depends_on "maven" => :build
+  end
+
+  # Writes an exec script that invokes a java jar with vertx
+  def write_vertx_script target_jar, script_name, opts=""
+    (bin+script_name).write <<-EOS.undent
+      #!/bin/bash
+      exec vertx runzip #{opts} #{target_jar} "$@"
+    EOS
+  end
+
+  def install
+    if not build.head?
+      odie "galeb is currently a head-only formula."
+    end
+
+    # Build the package from source
+    java_home = ENV["JAVA_HOME"] = `/usr/libexec/java_home`.chomp
+    system "mvn", "clean", "package", "-DskipTests"
+
+    # Move libraries to `libexec` directory
+    libexec.install Dir["galeb-router/target/*.jar"]
+    write_vertx_script libexec/"galeb-router-2.0-SNAPSHOT.jar", "galeb"
+  end
+end


### PR DESCRIPTION
http://galeb.io/

```
$ brew install --HEAD galeb
...

$ brew install --HEAD galeb
==> Installing galeb dependency: vert.x
==> Downloading http://dl.bintray.com/vertx/downloads/vert.x-2.1.5.tar.gz
######################################################################## 100.0%
🍺  /usr/local/Cellar/vert.x/2.1.5: 173 files, 9.4M, built in 7 seconds
==> Installing galeb
==> Cloning https://github.com/globocom/galeb.git
Cloning into '/Library/Caches/Homebrew/galeb--git'...
remote: Counting objects: 17, done.
remote: Compressing objects: 100% (16/16), done.
remote: Total 17 (delta 0), reused 14 (delta 0)
Unpacking objects: 100% (17/17), done.
Checking connectivity... done.
==> Checking out branch master
==> mvn clean package -DskipTests
🍺  /usr/local/Cellar/galeb/HEAD: 7 files, 224K, built in 21 seconds

$ galeb
Succeeded in deploying module from zip
[com.globo.galeb.verticles.RouteManagerVerticle@443751a1] route.add registered
[com.globo.galeb.verticles.RouterVerticle@647f84c9] route.add registered
[com.globo.galeb.verticles.RouterVerticle@209e235b] route.add registered
[com.globo.galeb.verticles.RouterVerticle@4b3e427e] route.add registered
...
```

Cc: @tuxmonteiro
