### PR TITLE
jxrlib: New Formula

### DIFF
--- a/jxrlib.rb
+++ b/jxrlib.rb
@@ -1,0 +1,19 @@
+class Jxrlib < Formula
+  desc "Tools for JPEG-XR image encoding/decoding"
+  homepage "https://jxrlib.codeplex.com/"
+
+  head "https://git01.codeplex.com/jxrlib", :using => :git
+
+  def install
+    system "make", "install", "DIR_INSTALL=#{prefix}"
+  end
+
+  test do
+    bmp = "Qk06AAAAAAAAADYAAAAoAAAAAQAAAAEAAAABABgAAAAAAAQAAADDDgAAww4AAAAAAAAAAAAA////AA==".unpack("m")[0]
+    infile  = "test.bmp"
+    outfile = "test.jxr"
+    File.open(infile, "wb") { |f| f.write bmp }
+    system bin/"JxrEncApp", "-i", infile,  "-o", outfile
+    system bin/"JxrDecApp", "-i", outfile, "-o", infile
+  end
+end


### PR DESCRIPTION
This formula provides the `JxrEncApp` and `JxrDecApp` utilities that allow to encode and decode [JPEG-XR](https://en.wikipedia.org/wiki/JPEG_XR) images. The utilities will also be used by imagemagick as a delegate to enable jxr support.

The formula is head only, because the latest stable release is from 2013 and can only be built on windows.