### PR TITLE
agedu: move to git

### DIFF
--- a/agedu.rb
+++ b/agedu.rb
@@ -4,9 +4,14 @@ class Agedu < Formula
   homepage 'http://www.chiark.greenend.org.uk/~sgtatham/agedu/'
 
   # The tarball here is not stable, and the checksum changes over time
-  head "http://www.chiark.greenend.org.uk/~sgtatham/agedu/agedu-r10126.tar.gz"
+  head "git://git.tartarus.org/simon/agedu.git"
+
+  depends_on 'autoconf' => :build
+  depends_on 'automake' => :build
+  depends_on 'halibut' => :build
 
   def install
+    system "./mkauto.sh"
     system "./configure", "--disable-dependency-tracking",
                           "--prefix=#{prefix}"
     system "make install"


### PR DESCRIPTION
Source code for agedu is now tracked in git, so the use of snapshot tarballs is no longer needed.