### PR TITLE
docker-osx-dev (new formula)

### DIFF
--- a/docker-osx-dev.rb
+++ b/docker-osx-dev.rb
@@ -1,0 +1,12 @@
+
+class DockerOsxDev < Formula
+  desc "A productive development environment with Docker on OS X"
+  homepage "https://github.com/brikis98/docker-osx-dev"
+  head "https://github.com/brikis98/docker-osx-dev.git"
+
+  def install
+    libexec.install Dir["*"]
+    bin.write_exec_script libexec/"src/docker-osx-dev"
+  end
+
+end


### PR DESCRIPTION
Related to https://github.com/brikis98/docker-osx-dev/pull/106

This PR creates a head only formula. `docker-osx-dev` still has to create a tag/version so it adheres to brew audit (more here: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Formula-Cookbook.md)

Ping @ain @brikis98 @JoyceBabu @aforward